### PR TITLE
Avoid crash when an error occurs in the request to pull the organization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/stretchr/testify v1.3.0
 )
+
+go 1.13

--- a/slab/topics.go
+++ b/slab/topics.go
@@ -44,7 +44,10 @@ func (t *TopicService) List() (*[]Topic, error) {
 		Organization *Organization `json:"organization"`
 	}
 	err := t.client.Do(context.Background(), query, nil, &resp)
-	return resp.Organization.Topics, err
+	if resp.Organization != nil {
+		return resp.Organization.Topics, err
+	}
+	return nil, err
 }
 
 // Get retrieves the details of a specific topic


### PR DESCRIPTION
This avoid to lookup into a nil pointer when an error occurs during the request