### PR TITLE
Breaking change: Topic.List does not return the posts anymore for performance reasons

### DIFF
--- a/slab/topics.go
+++ b/slab/topics.go
@@ -22,24 +22,51 @@ type Topic struct {
 	UpdatedAt   *DateTime `json:"updatedAt,omitempty"`
 }
 
-// List retrieves all the cwtopicsposts available in the organization including their details
+// List retrieves all the topics available in the organization including their details
 func (t *TopicService) List() (*[]Topic, error) {
 	query := `{
-        organization {
-            topics{
-                id,
-                name,
-                description,
+		organization {
+			topics{
+				id,
+				name,
+				description,
+				hierarchy,
+				parent{id},
+				ancestors{id},
+				children{id},
+				insertedAt,
+				updatedAt
+			}
+		}
+	}`
+	var resp struct {
+		Organization *Organization `json:"organization"`
+	}
+	err := t.client.Do(context.Background(), query, nil, &resp)
+	if resp.Organization != nil {
+		return resp.Organization.Topics, err
+	}
+	return nil, err
+}
+
+// ListWithPosts retrieves all the topics available including the ID and the title of the posts they contain in the organization including their details
+func (t *TopicService) ListWithPosts() (*[]Topic, error) {
+	query := `{
+		organization {
+			topics{
+				id,
+				name,
+				description,
 				posts{id, title},
 				hierarchy,
 				parent{id},
 				ancestors{id},
 				children{id},
-                insertedAt,
-                updatedAt
-            }
-        }
-    }`
+				insertedAt,
+				updatedAt
+			}
+		}
+	}`
 	var resp struct {
 		Organization *Organization `json:"organization"`
 	}
@@ -53,20 +80,20 @@ func (t *TopicService) List() (*[]Topic, error) {
 // Get retrieves the details of a specific topic
 func (t *TopicService) Get(id string) (*Topic, error) {
 	query := `
-    query ($id: ID){
-        topic(id: $id){
-                id,
-                name,
-                description,
-				posts{id, title},
-				hierarchy,
-				parent{id},
-				ancestors{id},
-				children{id},
-                insertedAt,
-                updatedAt
-        }
-    }`
+	query ($id: ID){
+		topic(id: $id){
+			id,
+			name,
+			description,
+			posts{id, title},
+			hierarchy,
+			parent{id},
+			ancestors{id},
+			children{id},
+			insertedAt,
+			updatedAt
+		}
+	}`
 	var resp struct {
 		Topic *Topic `json:"topic"`
 	}

--- a/slab/topics_test.go
+++ b/slab/topics_test.go
@@ -21,6 +21,58 @@ func TestTopicService_List(t *testing.T) {
 			ID: "abc123", Hierarchy: &[]string{"efg234.abc123"}, Ancestors: &[]Topic{{ID: "efg234"}},
 			Description: "Description of topic A.", InsertedAt: insertDate, UpdatedAt: updateDate,
 			Name: "Topic A", Parent: &Topic{ID: "efg234"}, Children: &[]Topic{{ID: "zzzblabla"}},
+		},
+		{
+			ID: "zzzblabla", Hierarchy: &[]string{"efg234.abc123.zzzblabla"},
+			Ancestors:   &[]Topic{{ID: "abc123"}, {ID: "efg234"}},
+			Description: "Description of topic B.", InsertedAt: insertDate, UpdatedAt: updateDate,
+			Name: "Topic B", Parent: &Topic{ID: "abc123"}, Children: &[]Topic{},
+		},
+	}
+	expectedResp := `{"data":{"organization":{"topics": [
+                {
+                    "id": "abc123",
+                    "hierarchy": ["efg234.abc123"],
+				    "ancestors": [{"id":"efg234"}],
+                    "children": [{ "id": "zzzblabla"}],
+                    "description": "Description of topic A.",
+					"insertedAt": "2019-05-01T22:44:33.078957Z",
+					"updatedAt":"2019-06-18T22:40:16.733422Z",
+                    "name": "Topic A",
+                    "parent": {"id": "efg234"}
+                },
+                {
+                    "ancestors": [ { "id": "abc123" }, { "id": "efg234" } ],
+                    "children": [],
+                    "description": "Description of topic B.",
+                    "hierarchy": [ "efg234.abc123.zzzblabla" ],
+                    "id": "zzzblabla",
+					"insertedAt": "2019-05-01T22:44:33.078957Z",
+					"updatedAt":"2019-06-18T22:40:16.733422Z",
+                    "name": "Topic B",
+                    "parent": { "id": "abc123" }
+                }
+            ]}}}`
+	c, _, teardown := setup(t, expectedResp)
+	defer teardown()
+
+	got, err := c.Topic.List()
+	if err != nil {
+		t.Errorf("Expecting no error, got: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("List returned: %#v\nwant %#v", got, want)
+	}
+}
+
+func TestTopicService_ListWithPosts(t *testing.T) {
+	insertDate := &DateTime{time.Date(2019, time.May, 1, 22, 44, 33, 78957000, time.UTC)}
+	updateDate := &DateTime{time.Date(2019, time.June, 18, 22, 40, 16, 733422000, time.UTC)}
+	want := &[]Topic{
+		{
+			ID: "abc123", Hierarchy: &[]string{"efg234.abc123"}, Ancestors: &[]Topic{{ID: "efg234"}},
+			Description: "Description of topic A.", InsertedAt: insertDate, UpdatedAt: updateDate,
+			Name: "Topic A", Parent: &Topic{ID: "efg234"}, Children: &[]Topic{{ID: "zzzblabla"}},
 			Posts: &[]Post{{ID: "postid1", Title: "Post 1 from topic A"}, {ID: "postid2", Title: "Post 2 from topic A"}},
 		},
 		{
@@ -66,7 +118,7 @@ func TestTopicService_List(t *testing.T) {
 	c, _, teardown := setup(t, expectedResp)
 	defer teardown()
 
-	got, err := c.Topic.List()
+	got, err := c.Topic.ListWithPosts()
 	if err != nil {
 		t.Errorf("Expecting no error, got: %v", err)
 	}


### PR DESCRIPTION
With the import we did from our old documentation system, listing the topics and including the posts is making the slab API timing out.
And we don't really need them there anyway so let's remove them and keep this ability in a separate function.